### PR TITLE
Eval compiled content

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ var createHamlPreprocessor = function(args, config, logger, helper) {
 
   return function(content, file, done) {
     log.debug('Processing "%s".', file.originalPath);
-    done(haml.compile(content))
+    var compiled = haml.compile(content);
+    done(eval(compiled))
   };
 };
 


### PR DESCRIPTION
Dunno how it should behave, maybe I just misunderstood something but without this change I just got a string that looks like a concatenation of strings:

``` js
var string = '"<some/>" + "<html/>"'
/\+/.test(string) // => true
```

After this change i got what i expect:

``` js
var string = '<some/><html/>'
```

Cheers
